### PR TITLE
Say what --project does, and what a mirror ref does not

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,25 @@ the commands are always runnable in every build.
   Requiring the prefix is a **namesquatting** guard, not tidiness: without it,
   whichever namespace the CLI defaulted to could shadow the other, and
   `TestCloneRefAlwaysRequiresItsForgePrefix` pins that no forge-less pair
-  resolves in either parser or in the command. It holds only for *intent* —
+  resolves in either parser, in `repo clone`, or in `resolveRepoRef` — the last
+  being the surface every other repo-ref command shares. It holds only for
+  *intent* —
   lookups are already unambiguous because native rows are stored prefixed in the
   same `full_name` index (`et/<project>/<repo>`), which is why the bare-pair
   `--repo` filters on `search`/`experts`/`explain` cannot cross namespaces
   either.
+  The native `/et/<project>/<repo>` path is **not** clone-only: it is the
+  `path` the API returns, and `resolveRepoRef` accepts it for every command
+  that takes a repo ref — `get`, `delete`, the `visibility` and `protection`
+  subtrees, and `grant repo add`/`list`/`remove` (COR-1632). The other two
+  clone shapes are not: a `/gh/` mirror ref is refused there (the by-name
+  lookup resolves a project and then a repo inside it, and a mirror is in no
+  project — so a mirror is addressed by ULID), and an `entire://` URL is not
+  parsed at all. `--project` serves the **bare-name** spelling alone, because
+  the control plane has no by-name repo route that is not project-scoped; the
+  path form is checked against it for agreement, and a ULID warns that it is
+  ignored rather than validating, which would cost a `GetRepo` on every command
+  but `repo get`.
   Native names are validated client-side against the server's own rules
   (`nativeProjectRe`/`nativeRepoRe`, mirroring `normalizeName` in entiredb
   `core/resource/project_name.go`); those bounds are server parity only and buy

--- a/cmd/entire/cli/grant.go
+++ b/cmd/entire/cli/grant.go
@@ -381,7 +381,7 @@ func newGrantRepoAddCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add <repo> <grantee>",
 		Short:   "Grant a user access to a repo",
-		Long:    "Grant a user (addressed as provider:handle, e.g. github:alice) access to a repo (name or ULID).",
+		Long:    "Grant a user (addressed as provider:handle, e.g. github:alice) access to a repo (a /et/<project>/<repo> path, a bare name with --project, or a ULID).",
 		Example: "  entire grant repo add web github:alice --project acme --role writer",
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -454,7 +454,7 @@ func newGrantRepoRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove <repo> <grantee>",
 		Short: "Revoke repo access from a grantee",
-		Long: "Revoke a grantee's access to a repo (addressed by name or ULID). " +
+		Long: "Revoke a grantee's access to a repo (addressed by a /et/<project>/<repo> path, a bare name with --project, or a ULID). " +
 			"The grantee is a provider-qualified handle (e.g. github:alice) or an " +
 			"account ULID.",
 		Example: "  entire grant repo remove web github:alice --project acme",

--- a/cmd/entire/cli/repo.go
+++ b/cmd/entire/cli/repo.go
@@ -449,9 +449,52 @@ func newRepoVisibilitySetCmd() *cobra.Command {
 }
 
 // bindRepoProjectFlag wires the shared --project scope used to resolve a repo
-// addressed by name (a repo name is unique only within its project). Ignored
-// when the repo arg is already a ULID; checked for agreement when it is a
-// /et/<project>/<repo> path, which names its own project.
+// addressed by a BARE NAME. That is the only form it serves: a repo name is
+// unique only within its project, and the control plane has no by-name route
+// that is not project-scoped (ListProjectRepos takes the project as a path
+// segment), so without the flag a bare name is not an address at all.
+//
+// The other two spellings carry their own project, so the flag cannot change
+// what they resolve to — and the two used to disagree about saying so. A
+// /et/<project>/<repo> path is checked for agreement by resolveRepoPathRef,
+// which costs nothing because it resolves that project anyway. A ULID
+// short-circuits resolveRepoRef before projectRef is ever read, so a flatly
+// wrong project was accepted in silence; warnRedundantProjectFlag is what ends
+// that.
 func bindRepoProjectFlag(cmd *cobra.Command, project *string) {
-	cmd.Flags().StringVar(project, "project", "", "Owning project (name or ULID); required when <repo> is a bare name")
+	cmd.Flags().StringVar(project, "project", "", "Owning project (name or ULID); required when <repo> is a bare name, redundant with a /"+nativeCloneForge+"/<project>/<repo> path or a ULID")
+	warnRedundantProjectFlag(cmd, project)
+}
+
+// warnRedundantProjectFlag reports on stderr that --project cannot affect the
+// lookup, when the ref identifies the repo on its own.
+//
+// It WARNS rather than refusing because addressing a repo by ULID with an
+// unconditional --project has been accepted since the flag shipped (ece9fb3dc,
+// June 2026) and is plausibly scripted; breaking that to report a flag that was
+// already being ignored is a poor trade. It does not VALIDATE because that
+// needs GetRepo's owningProjectId, an extra round trip on every command here
+// except `repo get` — which alone already fetches the repo and prints its
+// project.
+//
+// Wired as a PreRunE because the answer needs only the flag and args[0]: no
+// resolution, no network, and every command binding this flag takes the repo
+// ref as args[0]. An existing PreRunE is chained rather than clobbered, so a
+// command that grows one later does not silently lose the warning (or its own
+// hook).
+func warnRedundantProjectFlag(cmd *cobra.Command, project *string) {
+	prev := cmd.PreRunE
+	cmd.PreRunE = func(c *cobra.Command, args []string) error {
+		if prev != nil {
+			if err := prev(c, args); err != nil {
+				return err
+			}
+		}
+		// Changed(), not a non-empty value: an explicit --project "" is still
+		// the user saying something, and reporting it is the point.
+		if len(args) > 0 && c.Flags().Changed("project") && looksLikeULID(args[0]) {
+			fmt.Fprintf(c.ErrOrStderr(), "Note: --project %q is ignored — %s is a repo ULID, which identifies the repo on its own.\n", *project, args[0])
+		}
+		return nil
+	}
 }

--- a/cmd/entire/cli/repo_clone_test.go
+++ b/cmd/entire/cli/repo_clone_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -212,6 +213,28 @@ func TestCloneRefAlwaysRequiresItsForgePrefix(t *testing.T) {
 		msg := invalidCloneRefError("acme/tool", nativeErr, mirrorErr).Error()
 		require.Contains(t, msg, "/et/acme/tool")
 		require.Contains(t, msg, "/gh/acme/tool")
+	})
+
+	// `repo clone` is no longer the only command parsing a forge-prefixed ref:
+	// resolveRepoRef took the native grammar for `repo get`, `repo delete`, the
+	// visibility and protection subtrees, and `grant repo add/list/remove`
+	// (COR-1632). The guard follows the requirement rather than the command, so
+	// the same table runs against the second entry point — a bare pair must not
+	// become resolvable just because it was typed at a different subcommand.
+	t.Run("the shared repo-ref resolver refuses a bare pair too", func(t *testing.T) {
+		for _, ref := range append(bare, "github.com/acme/tool", "https://github.com/acme/tool") {
+			c, calls := resolveTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("a ref without a forge prefix reached the control plane: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusInternalServerError)
+			})
+			// With --project set as well: the flag must not become a way to
+			// have a forge-less pair read as a name inside that project.
+			for _, project := range []string{"", "acme"} {
+				_, err := resolveRepoRef(context.Background(), c, ref, project)
+				require.Errorf(t, err, "resolveRepoRef(%q, project=%q) must not accept a forge-less pair", ref, project)
+			}
+			require.Zerof(t, calls.Load(), "ref %q must be refused before the control plane", ref)
+		}
 	})
 }
 

--- a/cmd/entire/cli/repo_test.go
+++ b/cmd/entire/cli/repo_test.go
@@ -608,3 +608,70 @@ func TestRepoList_GroupedFlagHelp(t *testing.T) {
 	)
 	require.NotContains(t, stdout, "Filtering & Sorting Flags:")
 }
+
+// TestRepoProjectFlagRedundancyWarning covers the one spelling where --project
+// used to be swallowed in silence. A ULID identifies the repo globally, so the
+// flag cannot change what is resolved — resolveRepoRef returns before it is
+// ever read — and a user who supplied a project the repo is not in got a clean
+// success confirming a wrong belief.
+//
+// It is a warning, not a refusal: the combination has been accepted since the
+// flag shipped and may be scripted, and the command still does exactly what it
+// did. What changes is that it says so.
+//
+// Not parallel: swaps the package-level activeCoreClient seam via runCoreCmd.
+func TestRepoProjectFlagRedundancyWarning(t *testing.T) {
+	const repoULID = "0123456789ABCDEFGHJKMNPQR5"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := printJSON(w, &coreapi.Repo{ID: repoULID, Name: "web", OwningProjectId: ulidProjectWidgets}); err != nil {
+			t.Errorf("encode repo: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Run("a ULID ref warns that --project is ignored", func(t *testing.T) {
+		stdout, stderr, err := runCoreCmd(t, newRepoGetCmd, srv.URL, repoULID, "--project", "not-this-project")
+		require.NoError(t, err, "the command must still succeed")
+		require.Contains(t, stdout, repoULID, "the repo must still be shown")
+		require.Contains(t, stderr, "--project")
+		require.Contains(t, stderr, "ignored")
+	})
+
+	t.Run("an explicit empty --project still warns", func(t *testing.T) {
+		// Changed(), not a non-empty value: --project "" is still the user
+		// saying something about this repo's project, and it is still ignored.
+		_, stderr, err := runCoreCmd(t, newRepoGetCmd, srv.URL, repoULID, "--project", "")
+		require.NoError(t, err)
+		require.Contains(t, stderr, "ignored")
+	})
+
+	t.Run("a ULID ref without the flag says nothing", func(t *testing.T) {
+		_, stderr, err := runCoreCmd(t, newRepoGetCmd, srv.URL, repoULID)
+		require.NoError(t, err)
+		require.NotContains(t, stderr, "ignored")
+	})
+
+	t.Run("the warning is wired on every command binding the flag", func(t *testing.T) {
+		// The flag is bound in three files across four command families; the
+		// warning rides on bindRepoProjectFlag so it cannot be wired for some
+		// and missed for others. Asserting the PreRunE exists is what pins
+		// that, without standing up a server per command.
+		for name, newCmd := range map[string]func() *cobra.Command{
+			"repo get":               newRepoGetCmd,
+			"repo delete":            newRepoDeleteCmd,
+			"repo visibility get":    newRepoVisibilityGetCmd,
+			"repo visibility set":    newRepoVisibilitySetCmd,
+			"repo protection list":   newRepoProtectionListCmd,
+			"repo protection add":    newRepoProtectionAddCmd,
+			"repo protection remove": newRepoProtectionRemoveCmd,
+			"grant repo add":         newGrantRepoAddCmd,
+			"grant repo list":        newGrantRepoListCmd,
+			"grant repo remove":      newGrantRepoRemoveCmd,
+		} {
+			cmd := newCmd()
+			require.NotNilf(t, cmd.Flags().Lookup("project"), "%s must bind --project", name)
+			require.NotNilf(t, cmd.PreRunE, "%s must carry the redundancy check", name)
+		}
+	})
+}

--- a/cmd/entire/cli/resolveref.go
+++ b/cmd/entire/cli/resolveref.go
@@ -248,8 +248,18 @@ func resolveRepoRef(ctx context.Context, c repoRefClient, ref, projectRef string
 // and project names are globally unique), a ULID against the resolved project
 // id — neither costs an extra round trip.
 func resolveRepoPathRef(ctx context.Context, c repoRefClient, ref, projectRef string) (string, error) {
+	// The refusal is about the ref SHAPE, not about the command. Several
+	// commands sharing this resolver DO address mirror repos by ULID — `repo
+	// protection list` has a purpose-built mirror branch (protectionMirrorNote)
+	// telling the user branch protection is governed upstream, which is a better
+	// answer than any this message could give. Saying "this command addresses
+	// Entire-native repos" was therefore false, and pointing at `entire repo
+	// mirror` is a dead end from `repo protection` and `repo visibility`, which
+	// have no counterpart there. What genuinely cannot work is the by-name
+	// lookup below: it resolves a project and then a repo inside it, and a
+	// mirror is in no project. So name the way through — the ULID.
 	if declaresForge(ref, mirrorCloneForge) {
-		return "", fmt.Errorf("repo %q is a GitHub mirror ref; this command addresses Entire-native repos — manage mirrors with `entire repo mirror`", ref)
+		return "", fmt.Errorf("repo %q is a GitHub mirror ref; only the native /%s/<project>/<repo> path resolves by name here — pass the repo's ULID instead, or see `entire repo mirror` for the mirror-specific commands", ref, nativeCloneForge)
 	}
 	project, repoName, parseErr := parseNativeCloneRef(ref)
 	if parseErr != nil {
@@ -259,9 +269,21 @@ func resolveRepoPathRef(ctx context.Context, c repoRefClient, ref, projectRef st
 		// A bare <a>/<b> names no forge (#2252): suggest the native reading when
 		// it would parse, instead of guessing it or 404ing a by-name lookup that
 		// can never match a slash-bearing name.
+		//
+		// Deliberately not bareRefSuggestions, which answers the same question
+		// for `repo clone`: it also offers the /gh/ reading, and this resolver
+		// refuses /gh/ refs outright (see above). A suggestion that fails on the
+		// next run is worse than none.
 		native := "/" + nativeCloneForge + "/" + trimRefPrefix(ref)
 		if _, _, err := parseNativeCloneRef(native); err == nil {
-			return "", fmt.Errorf("repo ref %q must name its forge — did you mean %s?", ref, native)
+			// The suggested path names its own project, so a --project already
+			// on the command line would fail the agreement check below on the
+			// very next run. Say so here rather than making them find out.
+			drop := ""
+			if projectRef != "" {
+				drop = fmt.Sprintf(" (and drop --project %q, which the path supplies)", projectRef)
+			}
+			return "", fmt.Errorf("repo ref %q must name its forge — did you mean %s?%s", ref, native, drop)
 		}
 		return "", fmt.Errorf("invalid repo ref %q: expected /%s/<project>/<repo>, a repo name with --project, or a repo ULID", ref, nativeCloneForge)
 	}

--- a/cmd/entire/cli/resolveref_test.go
+++ b/cmd/entire/cli/resolveref_test.go
@@ -367,6 +367,51 @@ func TestResolveRepoRef_NativePath(t *testing.T) {
 		refuseLocally(t, "/gh/entirehq/entire-api", "entire repo mirror")
 	})
 
+	// The message describes the REF, not the command. Several commands sharing
+	// this resolver do address mirror repos by ULID — `repo protection list`
+	// answers one with protectionMirrorNote — so claiming the command is
+	// native-only was false, and `entire repo mirror` has no visibility or
+	// protection counterpart to send those callers to. Naming the ULID is the
+	// part that is true everywhere and actually unblocks the user.
+	t.Run("the mirror refusal names the ULID as the way through", func(t *testing.T) {
+		t.Parallel()
+		c, _ := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := resolveRepoRef(context.Background(), c, "/gh/entirehq/entire-api", "")
+		if err == nil {
+			t.Fatal("a /gh/ ref must be refused")
+		}
+		if !strings.Contains(err.Error(), "ULID") {
+			t.Errorf("mirror refusal = %q, want it to offer the ULID", err)
+		}
+		if strings.Contains(err.Error(), "addresses Entire-native repos") {
+			t.Errorf("mirror refusal must not claim the command is native-only: %q", err)
+		}
+	})
+
+	// Following the suggestion with the flag still set would fail the agreement
+	// check on the very next run, so the suggestion has to mention it.
+	t.Run("the forge suggestion says to drop a --project that would then clash", func(t *testing.T) {
+		t.Parallel()
+		c, calls := resolveTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			t.Error("a forge-less pair must not reach the control plane")
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		_, err := resolveRepoRef(context.Background(), c, "acme/tool", "widgets")
+		if err == nil {
+			t.Fatal("a forge-less pair must be refused")
+		}
+		for _, want := range []string{"/et/acme/tool", "--project", "widgets"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("suggestion = %q, want it to contain %q", err, want)
+			}
+		}
+		if n := calls.Load(); n != 0 {
+			t.Errorf("made %d HTTP calls, want 0", n)
+		}
+	})
+
 	t.Run("a bare pair names no forge and is refused with the /et/ suggestion", func(t *testing.T) {
 		t.Parallel()
 		refuseLocally(t, "widgets/web", "/et/widgets/web")


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/cli/trails/1318
<!-- entire-trail-link-end -->

Five follow-ups to #2387, which took the native `/et/<project>/<repo>` path into `resolveRepoRef` and so into every command that resolves a repo ref — ten of them, not the two whose help text was updated. No behaviour that #2387 added changes here; what changes is the one spelling it left silent, one message that was wrong, and the text that went stale around it.

## `--project` was left in an indefensible middle

The flag serves the **bare-name** spelling alone. A repo name is unique only within a project, and the control plane has no by-name route that is not project-scoped (`ListProjectRepos` takes the project as a path segment), so without the flag a bare name is not an address at all. The other two spellings carry their own project — and the two disagreed about saying so:

| ref | `--project` | before |
| --- | --- | --- |
| bare name | required | consulted |
| `/et/<project>/<repo>` | redundant | checked for agreement |
| ULID | meaningless | **silently ignored** |

A ULID short-circuits `resolveRepoRef` before `projectRef` is ever read, so `entire repo get 01ABC… --project a-project-this-repo-is-not-in` succeeded cleanly and confirmed a wrong belief. It now says so on stderr.

It **warns** rather than refusing because the combination has been accepted since the flag shipped (`ece9fb3dc`, June 2026) and is plausibly scripted — breaking that to report a flag that was already being ignored is a poor trade. It does not **validate** because that needs `GetRepo`'s `owningProjectId`, an extra round trip on every command here except `repo get`, which alone already fetches the repo and prints its project. The check rides on `bindRepoProjectFlag` as a chained `PreRunE`, so it cannot be wired for some of the ten commands and missed for others; a test asserts all ten carry it.

## The `/gh/` refusal said something false

> repo "/gh/entirehq/entire-api" is a GitHub mirror ref; this command addresses Entire-native repos — manage mirrors with `entire repo mirror`

Several commands sharing this resolver *do* address mirror repos, by ULID. `repo protection list` has a purpose-built mirror branch (`repo_protection.go:165`) that answers one with `protectionMirrorNote` — *"GitHub mirror: branch protection is governed by the upstream repository"* — which is strictly better than the refusal. And `entire repo mirror`, where it sent them, has no protection or visibility counterpart, so it is a dead end from two of the four families.

What genuinely cannot work is the by-name lookup: it resolves a project and then a repo inside it, and a mirror is in no project. The message now describes the **ref shape** and names the ULID as the way through.

## Stale text from the same change

- `grant repo add` and `grant repo remove` still told the user a repo is addressed "by name or ULID".
- The shared `--project` description said "required when `<repo>` is a bare name" — advertising a non-bare form that seven of the ten commands never named.
- CLAUDE.md still framed the native path as clone-only. It now records that ten commands take it, and that the *other* two clone shapes do not work there (a `/gh/` ref is refused, an `entire://` URL is not parsed at all) — the asymmetry is the part worth having written down.
- The `#2252` suggestion dropped a `--project` the user had already supplied: follow `did you mean /et/acme/tool?` literally with `--project widgets` still set and the next run fails the agreement check. It now says to drop it.
- A comment on why the suggestion is not `bareRefSuggestions`: that helper also offers the `/gh/` reading, which this resolver refuses outright, and a suggestion that fails on the next run is worse than none.

## The guard test follows the requirement, not the command

CLAUDE.md describes `TestCloneRefAlwaysRequiresItsForgePrefix` as pinning that no forge-less pair resolves "in either parser or in the command" — but `repo clone` is no longer the only command parsing a forge-prefixed ref. Its table now runs against `resolveRepoRef` as well, with and without `--project`, so the flag cannot become a way to have a bare pair read as a name inside that project.

I measured this before writing it: every entry in that table, plus `github.com/acme/tool`, `https://github.com/…`, `git/acme/tool`, `ET/widgets/web` and `//et/widgets/web`, is already refused with **zero** HTTP calls. The namesquatting invariant held; nothing pinned it at the second entry point.

## Verification

`mise run fmt && mise run lint` clean. `mise run test:ci`: all of `cmd/entire/cli/...` passes. One failure, `TestOpenCodeSeedRepoPlantsDeps` in `e2e/agents`, reproduces on clean `origin/main` (opencode dep-seeding cache) and is untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing help, stderr warnings, and local validation messages only; no changes to resolution logic beyond clearer errors and the new ULID + --project notice.
> 
> **Overview**
> This PR tightens **repo ref UX** after native `/et/...` paths landed in shared `resolveRepoRef`: it documents what `--project` is for, surfaces mistakes users could make silently, and fixes a couple of misleading errors.
> 
> **`--project` behavior is now explicit.** The flag only applies to **bare repo names**; `/et/<project>/<repo>` paths are checked for agreement and repo **ULIDs** ignore it. When someone passes `--project` with a ULID, commands now print a **stderr note** that the flag is ignored (still succeeds, for scripted compatibility), wired through `bindRepoProjectFlag` on all commands that use it. Help text and `grant repo` long descriptions now list the three accepted spellings (path, bare name + `--project`, ULID).
> 
> **Resolver errors are corrected.** Refusing `/gh/...` mirror refs no longer claims the command only works on native repos; the message points at **by-name limits** and using the repo **ULID** (mirror repos aren’t in a project). For forge-less `project/repo` pairs, the “did you mean `/et/...`?” hint can also say to **drop `--project`** when it would clash on the next run.
> 
> **Tests and docs follow the shared resolver.** Clone’s forge-prefix guard table also runs against `resolveRepoRef` (with and without `--project`). New tests cover the ULID + `--project` warning and the updated mirror/suggestion messages. `CLAUDE.md` records that the native path works across repo-ref commands, not only `repo clone`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498296f79a29e8c616f0b0aa695c1dd02dca33bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->